### PR TITLE
Address ISLANDORA-1760. Update PDF.js library to 1.4.20

### DIFF
--- a/islandora_pdfjs.drush.inc
+++ b/islandora_pdfjs.drush.inc
@@ -8,7 +8,8 @@
 /**
  * The PDF.js plugin URI.
  */
-define('PDFJS_DOWNLOAD_URI', 'https://github.com/mozilla/pdf.js/releases/download/v1.0.907/pdfjs-1.0.907-dist.zip');
+define('PDFJS_DOWNLOAD_URI', 'https://github.com/mozilla/pdf.js/releases/download/v1.4.20/pdfjs-1.4.20-dist.zip');
+
 
 /**
  * The initial PDF.js directory


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1760
# What does this Pull Request do?

The PDF attached to Jira ticket is blurry in PDF.js viewer. Updating to the latest version resolves the blurry issue.
# What's new?

The Islandora PDF.js module will now use the 1.4.20 version of the Mozilla PDF.js viewer.
# How should this be tested?

See steps to reproduce on the Jira ticket. After the new version is installed, the PDF will no longer be blurry in the PDF.js viewer.
# Additional Notes:
- Does this change require documentation to be updated?  No
- Does this change add any new dependencies? No
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
- Could this change impact execution of existing code? No
# Interested parties

@Islandora/7-x-1-x-committers as I'm the maintainer.
