### PR TITLE
add pdf viewer to newspaperIssueCModel

### DIFF
--- a/islandora_pdfjs.module
+++ b/islandora_pdfjs.module
@@ -42,7 +42,8 @@ function islandora_pdfjs_islandora_viewer_info() {
       'model' => array(
         'islandora:sp_pdf',
         'islandora:bookCModel',
-        'islandora:pageCModel'),
+        'islandora:pageCModel',
+        'islandora:newspaperIssueCModel'),
       'mimetype' => array('application/pdf'),
     ),
   );


### PR DESCRIPTION
Github issue:

https://github.com/Islandora/islandora_pdfjs/issues/19


# What does this Pull Request do?

Allow users to select pdf viewer for newspaper module

# What's new?

Allow users to select pdf viewer for newspaper module 

# How should this be tested?

Install module - select pdf-js as viewer.  Go to newspaper and make sure viewer is used.

# Additional Notes:
None
 
# Interested parties
 @Islandora/7-x-1-x-committers

