### PR TITLE
Changed hook_preprocess_theme() to template_preprocess_HOOK()

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -6,9 +6,9 @@
  */
 
 /**
- * Implements hook_preprocess_theme().
+ * Implements template_preprocess_HOOK().
  */
-function islandora_pdfjs_preprocess_islandora_pdfjs(array &$variables) {
+function template_preprocess_islandora_pdfjs(array &$variables) {
   $fedora_object = $variables['fedora_object'];
   $dsid = (isset($variables['dsid']) ? $variables['dsid'] : NULL);
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1071

# What does this Pull Request do?

This pull request ensures that when a function in this module implements hook_theme() that the template_preprocess hook is called to allow overriding variables further down the processing chain.

# What's new?

One function name has been changed to begin with ‘template’ instead of islandora_pdfjs.

# Interested parties

@Islandora/7-x-1-x-committers
