### PR TITLE
fix up dsid check in conditional.

### DIFF
--- a/islandora_pdfjs.module
+++ b/islandora_pdfjs.module
@@ -62,7 +62,7 @@ function islandora_pdfjs_islandora_viewer_info() {
  */
 function islandora_pdfjs_viewer_callback(array $params, $fedora_object = NULL) {
   $dsid = NULL;
-  if (isset($params['dsid']) && !empty($params['dsid']) && isset($fedora_object[$dsid])) {
+  if (isset($params['dsid']) && !empty($params['dsid']) && isset($fedora_object[$params['dsid']])) {
     $dsid = $params['dsid'];
   }
   else {


### PR DESCRIPTION
# What does this Pull Request do?

The first `if` test never returns true because of the NULL assignment to `$dsid` in the preceding line.
Guessing at the intent of the original authors, this PR alters that component of the conditional to accept incoming param `array('dsid' => 'SNOWFLAKE_PDF_DSID')`.

With this PR, users of this function should now (or once again) be able to specify an arbitrary DSID label for the PDF datastream that they wish to render with PDFjs.

# What's new?

Updates conditional so that its logic has a chance of being used. Updates the check to look into the incoming `$params` array for a custom dsid label, rather than evaluating the variable `$dsid` which is NULL.

# How should this be tested?

In the preprocess function of a custom module, attempt to add viewer markup for a PDF datastream that has a custom label, for example:

~~~

module_load_include('inc', 'islandora', 'includes/solution_packs');
$viewer = islandora_get_viewer(array('dsid' => 'INDEX'), 'islandora_pdf_viewers', $islandora_object);
$variables['index_pdf'] = $viewer ? $viewer : '';

~~~
