### PR TITLE
Check the set  has pdf mimetype

### DIFF
--- a/islandora_pdfjs.module
+++ b/islandora_pdfjs.module
@@ -63,7 +63,8 @@ function islandora_pdfjs_islandora_viewer_info() {
  */
 function islandora_pdfjs_viewer_callback(array $params, $fedora_object = NULL) {
   $dsid = NULL;
-  if (isset($params['dsid']) && !empty($params['dsid']) && isset($fedora_object[$params['dsid']])) {
+  if (isset($params['dsid']) && !empty($params['dsid']) && isset($fedora_object[$params['dsid']]) &&
+    $fedora_object[$params['dsid']]->mimetype == 'application/pdf') {
     $dsid = $params['dsid'];
   }
   else {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2464

# What does this Pull Request do?

If there is a provided `dsid` parameter check that the datastream is a PDF before trying to display it.

# How should this be tested?

1. Create a book or newspaper
1. Switch the page or newspaper page viewer from OpenSeadragon to PDF.js
1. Try to view a page, and see the corrupt PDF error.
1. Apply/Download this patch
1. Reload and now get the PDF (assuming the page has a PDF datastream or an OBJ which is a PDF).

# Additional Notes:

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers @jonathangreen @noahwsmith
