### PR TITLE
Update PDF.js version

### DIFF
--- a/islandora_pdfjs.drush.inc
+++ b/islandora_pdfjs.drush.inc
@@ -8,7 +8,7 @@
 /**
  * The PDF.js plugin URI.
  */
-define('PDFJS_DOWNLOAD_URI', 'https://github.com/mozilla/pdf.js/releases/download/v1.10.88/pdfjs-1.10.88-dist.zip');
+define('PDFJS_DOWNLOAD_URI', 'https://github.com/mozilla/pdf.js/releases/download/v2.10.377/pdfjs-2.10.377-dist.zip');
 
 /**
  * The initial PDF.js directory


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/ISLANDORA-2530

* Other Relevant Links https://islandora.slack.com/archives/CLL691ESC/p1630584767004100

# What does this Pull Request do?

The PDF viewer provided by the pdfjs module has begun failing to load pages. Checking in your browser's debugging console indicates PDF.js is the culprit. Updating the version used in the module fixes the problem.

# What's new?
Updates PDF.js to the current version (2.10.377)

# How should this be tested?

* Load a PDF and view it using the un-updated viewer
* see pages fail to load
* check your browser's console to see an error related to PDF.js
* deploy the updated version of the module
* reload your PDF in the viewer
* confirm the pages load
* (optional) check your console to confirm PDF.js 2.10.377 is being utilized


# Additional Notes:
The new version of PDF.js additionally adds some new viewing options, e.g. horizontal scrolling

# Interested parties
@Islandora/7-x-1-x-committers
